### PR TITLE
MakePangenome: stop iterations when changes are small

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ set(MIN_LENGTH 100 CACHE STRING "Minimum acceptable length of fragment")
 set(FRAME_LENGTH 100 CACHE STRING "Length of alignment checker frame (b.p.)")
 set(MIN_IDENTITY 0.9 CACHE STRING "Minimum acceptable identity of block")
 set(MIN_END 10 CACHE STRING "Minimum number of end good columns")
+set(MIN_REL_DISTANCE 0.001 CACHE STRING
+    "Minimum relative distance from previous iteration")
 set(ANCHOR_SIZE 20 CACHE STRING "Anchor size (AnchorFinder)")
 set(ANCHOR_FP 0.1 CACHE STRING
     "Probability of false positive in Bloom filter")

--- a/src/algo/Pipe.cpp
+++ b/src/algo/Pipe.cpp
@@ -17,9 +17,11 @@ namespace npge {
 struct Pipe::Impl {
     std::vector<Processor*> processors_;
     int max_iterations_;
+    bool stopped_;
 
     Impl():
-        max_iterations_(1) {
+        max_iterations_(1),
+        stopped_(false) {
     }
 };
 
@@ -51,18 +53,26 @@ std::vector<Processor*> Pipe::processors() const {
     return impl_->processors_;
 }
 
+void Pipe::stop() {
+    impl_->stopped_ = true;
+}
+
 void Pipe::run_impl() const {
     BOOST_FOREACH (Processor* processor, impl_->processors_) {
         processor->set_workers(workers());
     }
     std::set<hash_t> hashes;
     hashes.insert(blockset_hash(*block_set(), workers()));
+    impl_->stopped_ = false;
     for (int i = 0; i < max_iterations() || max_iterations() == -1; i++) {
         BOOST_FOREACH (Processor* processor, impl_->processors_) {
             processor->run();
         }
         hash_t new_hash = blockset_hash(*block_set(), workers());
         if (hashes.find(new_hash) != hashes.end()) {
+            break;
+        }
+        if (impl_->stopped_) {
             break;
         }
         hashes.insert(new_hash);

--- a/src/algo/Pipe.hpp
+++ b/src/algo/Pipe.hpp
@@ -44,6 +44,9 @@ public:
     /** Return list of processors added */
     std::vector<Processor*> processors() const;
 
+    /** Stop after current iteration */
+    void stop();
+
 protected:
     void run_impl() const;
 

--- a/src/algo/algo_lua.cpp
+++ b/src/algo/algo_lua.cpp
@@ -562,6 +562,7 @@ static luabind::scope register_pipe() {
            .def("max_iterations", &Pipe::max_iterations)
            .def("set_max_iterations", &Pipe::set_max_iterations)
            .def("processors", &Pipe::processors)
+           .def("stop", &Pipe::stop)
           ;
 }
 

--- a/src/algo/algo_lua.cpp
+++ b/src/algo/algo_lua.cpp
@@ -533,6 +533,10 @@ static void delete_pipe(Pipe* p) {
     delete p;
 }
 
+static Pipe* pipe_from_processor(Processor* p) {
+    return D_CAST<Pipe*>(p);
+}
+
 static void pipe_add(Pipe* pipe, Processor* p) {
     pipe->add(p);
 }
@@ -553,7 +557,8 @@ static luabind::scope register_pipe() {
     return class_<Pipe, Processor>("Pipe")
            .scope [
                def("new", &new_pipe),
-               def("delete", &delete_pipe)
+               def("delete", &delete_pipe),
+               def("from_processor", &pipe_from_processor)
            ]
            .def("add", &Pipe::add)
            .def("add", &pipe_add)

--- a/src/algo/lua_lib.lua
+++ b/src/algo/lua_lib.lua
@@ -443,7 +443,8 @@ register_p('StopIfTooSimilar', function()
     p:set_action(function(p)
         local new_bs = npge.algo.Cover(
             npge.convert.old2new.blockset(
-                p:block_set()
+                p:block_set(),
+                bs_from_prev_iteration -- don't recreate seqs
             )
         )
         if bs_from_prev_iteration then

--- a/src/algo/lua_lib.lua
+++ b/src/algo/lua_lib.lua
@@ -449,23 +449,13 @@ register_p('StopIfTooSimilar', function()
         )
         if bs_from_prev_iteration then
             local prev_bs = bs_from_prev_iteration
-            -- TODO use npge.algo.Compare...
-            local total_length = 0
-            for seq in prev_bs:iterSequences() do
-                total_length = total_length + seq:length()
-            end
             local mul = npge.algo.Multiply(prev_bs, new_bs)
-            local _, conflicts = npge.algo.SplitMultiplication(
+            local common, conflicts = npge.algo.SplitMultiplication(
                 prev_bs, new_bs, mul
             )
-            local conflicts_length = 0
-            for conflict in conflicts:iterBlocks() do
-                -- TODO omit blocks owned by minor blocks
-                for f in conflict:iterFragments() do
-                    conflicts_length = conflicts_length + f:length()
-                end
-            end
-            local rel_dist = conflicts_length / total_length
+            local abs_dist, rel_dist = npge.algo.NpgDistance(
+                prev_bs, new_bs, conflicts, common
+            )
             print("Distance from previous pre-pangenome: ", rel_dist)
             if rel_dist < p:opt_value('min-rel-distance'):to_d() then
                 Pipe.from_processor(p:parent()):stop()

--- a/src/algo/opts_lib.cpp.in
+++ b/src/algo/opts_lib.cpp.in
@@ -106,6 +106,11 @@ void add_opts(Meta* meta) {
                   "Minimum number of end good columns "
                   "(b.p.)");
     meta->set_section("MIN_END", "main");
+    meta->set_opt("MIN_REL_DISTANCE",
+                  D(${MIN_REL_DISTANCE}),
+                  "Minimum relative distance from previous "
+                  "iteration ");
+    meta->set_section("MIN_REL_DISTANCE", "main");
     meta->set_opt("ANCHOR_SIZE", int(${ANCHOR_SIZE}),
                   "Anchor size (b.p.)");
     meta->set_section("ANCHOR_SIZE", "anchor");


### PR DESCRIPTION
Time of `MakePangenome` for 17 genomes of Brucella.

Before:

```
real    57m21.695s
user    192m16.321s
sys     1m33.414s
```

After:

```
real    43m12.552s
user    138m0.562s
sys     0m19.985s
```

Distance between the two pangenomes: 471779 b.p., 0.8%.

New config option: `MIN_REL_DISTANCE = 0.001`
