### PR TITLE
log: fix error when printing sizes in Lua 5.3

### DIFF
--- a/src/algo/lua_lib.lua
+++ b/src/algo/lua_lib.lua
@@ -501,10 +501,10 @@ function reportStat(log, property, min, max, med, avg)
         capitalized = property:sub(1, 1):upper() .. property:sub(2)
         log("%s:\t%d", capitalized, min)
     else
-        log("Minimum %s:\t%d", property, min)
-        log("Median %s:\t%d", property, med)
-        log("Average %s:\t%d", property, avg)
-        log("Maximum %s:\t%d", property, max)
+        log("Minimum %s:\t%d", property, math.floor(min))
+        log("Median %s:\t%d", property, math.floor(med))
+        log("Average %s:\t%d", property, math.floor(avg))
+        log("Maximum %s:\t%d", property, math.floor(max))
     end
 end
 


### PR DESCRIPTION
npge MakePangenome
Running MakePangenome..
Information about input data:
 Number of genomes:     3
 Number of sequences:   6
 Number of sequences per genome:        2
 Total length of input (bp):    9997048
 Minimum genome length (bp):    3286032
 Median genome length (bp):     3311748
[string "/home/travis/build/npge/npge/src/algo/lua_lib..."]:495: bad argument
