### PR TITLE
Improve MyApplication class

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -13,7 +13,12 @@
 
 class MyApplication : public QApplication {
 public:
-    MyApplication(int argc, char* argv[]):
+    // Pass argc by reference
+    // Otherwise we give reference to stack variable
+    // Which results in memory error (segfault)
+    // When breaking Qt's  main loop
+    // (e.g. exec() of dialogs or message boxes)
+    MyApplication(int& argc, char* argv[]):
         QApplication(argc, argv) {
     }
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -13,11 +13,11 @@
 
 class MyApplication : public QApplication {
 public:
-    // Pass argc by reference
+    // Pass argc by reference.
     // Otherwise we give reference to stack variable
-    // Which results in memory error (segfault)
-    // When breaking Qt's  main loop
-    // (e.g. exec() of dialogs or message boxes)
+    // which results in memory error (segfault)
+    // when breaking Qt's main loop
+    // (e.g. exec() of dialogs or message boxes).
     MyApplication(int& argc, char* argv[]):
         QApplication(argc, argv) {
     }

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -17,18 +17,18 @@ public:
         QApplication(argc, argv) {
     }
 
-    bool notify(QObject* receiver, QEvent* e) {
+    bool notify(QObject* receiver, QEvent* event) {
         try {
-            return QApplication::notify(receiver, e);
-        } catch (const std::exception& e) {
+            return QApplication::notify(receiver, event);
+        } catch (const std::exception& error) {
             using namespace npge;
-            QString what = QString::fromStdString(htmlencode(e.what()));
-            QString error = "<b>The error occurred</b>."
-                            "<br/><br/>"
-                            "Description for developers:"
-                            "<br/><br/>" + what;
+            QString what = QString::fromStdString(htmlencode(error.what()));
+            QString message = "<b>The error occurred</b>."
+                              "<br/><br/>"
+                              "Description for developers:"
+                              "<br/><br/>" + what;
             QErrorMessage::qtHandler()->resize(400, 300);
-            QErrorMessage::qtHandler()->showMessage(error);
+            QErrorMessage::qtHandler()->showMessage(message);
             return false;
         }
     }


### PR DESCRIPTION
- Don't use tha same names for different variables
- Pass argc by reference.
  Otherwise we give reference to stack variable which results in memory error (segfault) when
  breaking Qt's main loop (e.g. exec() of dialogs or message boxes).
